### PR TITLE
Correct missing include and linked uuid lib.

### DIFF
--- a/taskwarrior-sys/build.rs
+++ b/taskwarrior-sys/build.rs
@@ -44,6 +44,7 @@ fn main() {
 
     println!("cargo:rustc-link-search=native=/opt/homebrew/opt/gnutls/lib");
     println!("cargo:rustc-link-lib=dylib=gnutls");
+    println!("cargo:rustc-link-lib=dylib=uuid");
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")

--- a/taskwarrior-sys/wrapper.cpp
+++ b/taskwarrior-sys/wrapper.cpp
@@ -1,6 +1,7 @@
 #include "wrapper.h"
 #include "vendor/taskwarrior/src/Context.h"
 #include <iostream>
+#include <cstring>
 
 Context *newContext() { return new Context; }
 


### PR DESCRIPTION
## Description

1. Correct missing cstring include in wrapper.cpp which failed during `cargo build`
2. Correct missing uuid lib which caused a failure during `cargo test`.

Builds then succeed on Ubuntu.

### First issue:
```
  CXXFLAGS = None
  running: "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-I" "vendor/taskwarrior/src" "-I" "vendor/taskwarrior/src/commands" "-I" "vendor/taskwarrior/src/columns" "-I" "vendor/taskwarrior/src/libshared/src" "-std=c++17" "-o" "/home/cpugamerbb/workspace/forked/taskwarrior-rs/target/debug/build/taskwarrior-sys-6a0643e6d8231a2c/out/wrapper.o" "-c" "wrapper.cpp"
  cargo:warning=wrapper.cpp: In function ‘int Context_dispatch(Context*, char*)’:
  cargo:warning=wrapper.cpp:21:5: error: ‘strcpy’ was not declared in this scope
  cargo:warning=   21 |     strcpy(out, str.c_str());
  cargo:warning=      |     ^~~~~~
  cargo:warning=wrapper.cpp:4:1: note: ‘strcpy’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
  cargo:warning=    3 | #include <iostream>
  cargo:warning=  +++ |+#include <cstring>
  exit status: 1
```
### Second issue:
```
  = note: /usr/bin/ld: /home/cpugamerbb/workspace/forked/taskwarrior-rs/target/debug/build/taskwarrior-sys-6a0643e6d8231a2c/out/build/src/libtask.a(util.cpp.o): in function `uuid[abi:cxx11]()':
          util.cpp:(.text._Z4uuidB5cxx11v+0x35): undefined reference to `uuid_generate'
          /usr/bin/ld: util.cpp:(.text._Z4uuidB5cxx11v+0x72): undefined reference to `uuid_unparse_lower'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

error: could not compile `taskwarrior-sys` (lib test) due to previous error
```